### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Project site： <https://github.com/HomHomLin/Android-DivergeView>.
  * Linhonghong - <linhh90@163.com>
 
 
-##License
+## License
 Copyright 2016 LinHongHong
 
 Licensed under the Apache License, Version 2.0 (the "License");


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
